### PR TITLE
fix: Use chain name instead chain id in IBC paths

### DIFF
--- a/_IBC/archway-agoric.json
+++ b/_IBC/archway-agoric.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
-    "chain_name": "archway-1",
+    "chain_name": "archway",
     "client_id": "07-tendermint-23",
     "connection_id": "connection-21"
   },
   "chain_2": {
-    "chain_name": "agoric-3",
+    "chain_name": "agoric",
     "client_id": "07-tendermint-75",
     "connection_id": "connection-69"
   },

--- a/_IBC/archway-axelar.json
+++ b/_IBC/archway-axelar.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
-    "chain_name": "archway-1",
+    "chain_name": "archway",
     "client_id": "07-tendermint-16",
     "connection_id": "connection-17"
   },
   "chain_2": {
-    "chain_name": "axelar-dojo-1",
+    "chain_name": "axelar",
     "client_id": "07-tendermint-160",
     "connection_id": "connection-145"
   },
@@ -30,7 +30,7 @@
   "operators": [
     {
       "chain_1": {
-        "address": "archway1y8k9a33967dm9n7a8u2d2l6q9m7teecvnxy0t0" 
+        "address": "archway1y8k9a33967dm9n7a8u2d2l6q9m7teecvnxy0t0"
       },
       "chain_2": {
         "address": "axelar1e7k29yvxqmgrekznv9537gdtfxkqt69q7khktj"
@@ -41,7 +41,7 @@
     },
     {
       "chain_1": {
-        "address": "archway18p5jxxtsgdcn2un0jarase89a2cgtetyaf8qce" 
+        "address": "archway18p5jxxtsgdcn2un0jarase89a2cgtetyaf8qce"
       },
       "chain_2": {
         "address": "axelar18p5jxxtsgdcn2un0jarase89a2cgtetyvvdve0"

--- a/_IBC/archway-bitcanna.json
+++ b/_IBC/archway-bitcanna.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
-    "chain_name": "archway-1",
+    "chain_name": "archway",
     "client_id": "07-tendermint-37",
     "connection_id": "connection-40"
   },
   "chain_2": {
-    "chain_name": "bitcanna-1",
+    "chain_name": "bitcanna",
     "client_id": "07-tendermint-83",
     "connection_id": "connection-74"
   },

--- a/_IBC/archway-cosmoshub.json
+++ b/_IBC/archway-cosmoshub.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../ibc_data_schema.json",
   "chain_1": {
-    "chain_name": "archway-1",
+    "chain_name": "archway",
     "client_id": "07-tendermint-0",
     "connection_id": "connection-0"
   },
   "chain_2": {
-    "chain_name": "cosmoshub-4",
+    "chain_name": "cosmoshub",
     "client_id": "07-tendermint-1152",
     "connection_id": "connection-873"
   },
@@ -30,7 +30,7 @@
   "operators": [
     {
       "chain_1": {
-        "address": "archway1y8k9a33967dm9n7a8u2d2l6q9m7teecvnxy0t0" 
+        "address": "archway1y8k9a33967dm9n7a8u2d2l6q9m7teecvnxy0t0"
       },
       "chain_2": {
         "address": "cosmos1nusnne6zlx3ymfdzcllsdsepu7wctxrpfamg4v"

--- a/_IBC/archway-jackal.json
+++ b/_IBC/archway-jackal.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../ibc_data_schema.json",
   "chain_1": {
-    "chain_name": "archway-1",
+    "chain_name": "archway",
     "client_id": "07-tendermint-17",
     "connection_id": "connection-18"
   },
   "chain_2": {
-    "chain_name": "jackal-1",
+    "chain_name": "jackal",
     "client_id": "07-tendermint-61",
     "connection_id": "connection-50"
   },

--- a/_IBC/archway-juno.json
+++ b/_IBC/archway-juno.json
@@ -1,23 +1,23 @@
 {
   "$schema": "../ibc_data_schema.json",
   "chain_1": {
-    "chain_name": "archway-1",
+    "chain_name": "archway",
     "client_id": "07-tendermint-18",
     "connection_id": "connection-19"
   },
   "chain_2": {
-    "chain_name": "juno-1",
+    "chain_name": "juno",
     "client_id": "07-tendermint-387",
     "connection_id": "connection-379"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-15", 
+        "channel_id": "channel-15",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-290", 
+        "channel_id": "channel-290",
         "port_id": "transfer"
       },
       "ordering": "unordered",

--- a/_IBC/archway-kujira.json
+++ b/_IBC/archway-kujira.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../ibc_data_schema.json",
   "chain_1": {
-    "chain_name": "archway-1",
+    "chain_name": "archway",
     "client_id": "07-tendermint-12",
     "connection_id": "connection-12"
   },
   "chain_2": {
-    "chain_name": "kaiyo-1",
+    "chain_name": "kujira",
     "client_id": "07-tendermint-144",
     "connection_id": "connection-110"
   },

--- a/_IBC/archway-noble.json
+++ b/_IBC/archway-noble.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
-    "chain_name": "archway-1",
+    "chain_name": "archway",
     "client_id": "07-tendermint-28",
     "connection_id": "connection-31"
   },
   "chain_2": {
-    "chain_name": "noble-1",
+    "chain_name": "noble",
     "client_id": "07-tendermint-17",
     "connection_id": "connection-26"
   },
@@ -28,4 +28,3 @@
     }
   ]
 }
-

--- a/_IBC/archway-nois.json
+++ b/_IBC/archway-nois.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
-    "chain_name": "archway-1",
+    "chain_name": "archway",
     "client_id": "07-tendermint-22",
     "connection_id": "connection-20"
   },
   "chain_2": {
-    "chain_name": "nois-1",
+    "chain_name": "nois",
     "client_id": "07-tendermint-15",
     "connection_id": "connection-9"
   },
@@ -40,6 +40,6 @@
       "tags": {
         "status": "live"
       }
-    }  
+    }
   ]
 }

--- a/_IBC/archway-osmosis.json
+++ b/_IBC/archway-osmosis.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../ibc_data_schema.json",
   "chain_1": {
-    "chain_name": "archway-1",
+    "chain_name": "archway",
     "client_id": "07-tendermint-2",
     "connection_id": "connection-1"
   },
   "chain_2": {
-    "chain_name": "osmosis-1",
+    "chain_name": "osmosis",
     "client_id": "07-tendermint-2850",
     "connection_id": "connection-2362"
   },
@@ -30,7 +30,7 @@
   "operators": [
     {
       "chain_1": {
-        "address": "archway1y8k9a33967dm9n7a8u2d2l6q9m7teecvnxy0t0" 
+        "address": "archway1y8k9a33967dm9n7a8u2d2l6q9m7teecvnxy0t0"
       },
       "chain_2": {
         "address": "osmo10f8g9ahz3nnt2h8ceyrw30suzpc2sc0x95tyg9"
@@ -41,7 +41,7 @@
     },
     {
       "chain_1": {
-        "address": "archway18p5jxxtsgdcn2un0jarase89a2cgtetyaf8qce" 
+        "address": "archway18p5jxxtsgdcn2un0jarase89a2cgtetyaf8qce"
       },
       "chain_2": {
         "address": "osmo18p5jxxtsgdcn2un0jarase89a2cgtetyqeg5yu"

--- a/_IBC/archway-quicksilver.json
+++ b/_IBC/archway-quicksilver.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../ibc_data_schema.json",
   "chain_1": {
-    "chain_name": "archway-1",
+    "chain_name": "archway",
     "client_id": "07-tendermint-36",
     "connection_id": "connection-39"
   },
   "chain_2": {
-    "chain_name": "quicksilver-2",
+    "chain_name": "quicksilver",
     "client_id": "07-tendermint-83",
     "connection_id": "connection-58"
   },
@@ -30,7 +30,7 @@
   "operators": [
     {
       "chain_1": {
-        "address": "archway1cx82d7pm4dgffy7a93rl6ul5g84vjgxkjd68em" 
+        "address": "archway1cx82d7pm4dgffy7a93rl6ul5g84vjgxkjd68em"
       },
       "chain_2": {
         "address": "quick1ln3l6waaqdjcskt3ztzqlzkpvmzp7zw4aq653n"
@@ -41,7 +41,7 @@
     },
     {
       "chain_1": {
-        "address": "archway1k670rkzc45xmdgywe4vxwheslk3kxm3h7gqk7f" 
+        "address": "archway1k670rkzc45xmdgywe4vxwheslk3kxm3h7gqk7f"
       },
       "chain_2": {
         "address": "quick1k670rkzc45xmdgywe4vxwheslk3kxm3hq8vqdv"
@@ -52,7 +52,7 @@
     },
     {
       "chain_1": {
-        "address": "archway1vfsly37szfmaukxy2gfqlt4cq82lwvfhh657u4" 
+        "address": "archway1vfsly37szfmaukxy2gfqlt4cq82lwvfhh657u4"
       },
       "chain_2": {
         "address": "quick19x3p4n600sgglqfudtnmdqmeanpce9npwv8mxf"

--- a/_IBC/archway-umee.json
+++ b/_IBC/archway-umee.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../ibc_data_schema.json",
   "chain_1": {
-    "chain_name": "archway-1",
+    "chain_name": "archway",
     "client_id": "07-tendermint-6",
     "connection_id": "connection-5"
   },
   "chain_2": {
-    "chain_name": "umee-1",
+    "chain_name": "umee",
     "client_id": "07-tendermint-228",
     "connection_id": "connection-190"
   },
@@ -30,7 +30,7 @@
   "operators": [
     {
       "chain_1": {
-        "address": "archway1y8k9a33967dm9n7a8u2d2l6q9m7teecvnxy0t0" 
+        "address": "archway1y8k9a33967dm9n7a8u2d2l6q9m7teecvnxy0t0"
       },
       "chain_2": {
         "address": "umee13qulwhndn3lldt9v2km7tu2gfnhg3emzxmu6vy"

--- a/_IBC/archwaytestnet-akashtestnet.json
+++ b/_IBC/archwaytestnet-akashtestnet.json
@@ -1,23 +1,23 @@
 {
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
-    "chain_name": "constantine-3",
-    "client_id": "07-tendermint-70",
-    "connection_id": "connection-60"
+    "chain_name": "archwaytestnet",
+    "client_id": "07-tendermint-45",
+    "connection_id": "connection-39"
   },
   "chain_2": {
-    "chain_name": "axelar-testnet-lisbon-3",
-    "client_id": "07-tendermint-603",
-    "connection_id": "connection-418"
+    "chain_name": "akashtestnet",
+    "client_id": "07-tendermint-4",
+    "connection_id": "connection-4"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-50",
+        "channel_id": "channel-34",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-305",
+        "channel_id": "channel-4",
         "port_id": "transfer"
       },
       "ordering": "unordered",

--- a/_IBC/archwaytestnet-axelartestnet.json
+++ b/_IBC/archwaytestnet-axelartestnet.json
@@ -1,23 +1,23 @@
 {
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
-    "chain_name": "constantine-3",
-    "client_id": "07-tendermint-45",
-    "connection_id": "connection-39"
+    "chain_name": "archwaytestnet",
+    "client_id": "07-tendermint-70",
+    "connection_id": "connection-60"
   },
   "chain_2": {
-    "chain_name": "sandbox-01",
-    "client_id": "07-tendermint-4",
-    "connection_id": "connection-4"
+    "chain_name": "axelartestnet",
+    "client_id": "07-tendermint-603",
+    "connection_id": "connection-418"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-34",
+        "channel_id": "channel-50",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-4",
+        "channel_id": "channel-305",
         "port_id": "transfer"
       },
       "ordering": "unordered",

--- a/_IBC/archwaytestnet-osmosistestnet.json
+++ b/_IBC/archwaytestnet-osmosistestnet.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../ibc_data_schema.json",
   "chain_1": {
-    "chain_name": "constantine-3",
+    "chain_name": "archwaytestnet",
     "client_id": "07-tendermint-69",
     "connection_id": "connection-59"
   },
   "chain_2": {
-    "chain_name": "osmo-test-5",
+    "chain_name": "osmosistestnet",
     "client_id": "07-tendermint-983",
     "connection_id": "connection-877"
   },


### PR DESCRIPTION
To be compliant with https://github.com/cosmos/chain-registry we should use chain name instead chain id in `chain_name` field in IBC paths