### PR TITLE
feat: Add IBC client trusting period validation pipeline

### DIFF
--- a/.github/workflows/ibc-path-validation.yaml
+++ b/.github/workflows/ibc-path-validation.yaml
@@ -1,0 +1,52 @@
+---
+name: Validate IBC path
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency: ci-${{ github.ref }}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      paths: ${{ steps.filter.outputs.ibc_files }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          list-files: shell
+          filters: |
+            ibc:
+              - added|modified: '_IBC/*.json'
+  Validation:
+    needs: changes
+    runs-on: ubuntu-latest
+    if: ${{ needs.changes.outputs.paths != null }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+            _IBC
+            scripts
+      - name: Install rly
+        uses: jaxxstorm/action-install-gh-release@v1
+        with:
+          repo: cosmos/relayer
+          tag: v2.4.2
+          binaries-location: Cosmos Relayer_2.4.2_linux_amd64
+      - name: Validate trusting period
+        shell: bash {0}
+        run: |
+          declare -i result=0
+          paths=(${{ needs.changes.outputs.paths }})
+          for path in "${paths[@]}"; do
+              $(scripts/ibc-path-validator.sh $path)
+              result=$(($result+$?))
+          done
+          if [[ "$result" -gt 0 ]]; then
+              echo "Error: Incorrect trusting period for all or some clients" >&2
+              exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 utils/__pycache__/
+.DS_Store

--- a/scripts/ibc-path-validator.sh
+++ b/scripts/ibc-path-validator.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DATA=$(jq . $1)
+RLY_HOME=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$RLY_HOME"
+}
+
+trap cleanup EXIT
+
+get_chains() {
+    jq -r '.chain_1.chain_name + " " + .chain_2.chain_name' <<< $DATA
+}
+
+get_clients() {
+    jq -r '.chain_1.client_id + " " + .chain_2.client_id' <<< $DATA
+}
+
+is_client_valid() {
+    local chain=$1
+    local client_id=$2
+
+    state=$(rly query client $chain $client_id --home "$RLY_HOME" | jq)
+    trusting_period=$(jq -r '.client_state.trusting_period | .[:-1]' <<< $state)
+    unbonding_period=$(jq -r '.client_state.unbonding_period | .[:-1]' <<< $state)
+    echo $trusting_period $unbonding_period \
+        | awk '{printf "trusting_period: %ss, required_trusting_period: %ss, unbonding_period: %ss\n", $1, (2/3 * $2), $2;}' >&2
+
+    echo $trusting_period $unbonding_period | awk '{if ($1 == 2/3 * $2) print "yes"; else print "no"}'
+}
+
+echo "Checking $1" >&2
+
+rly config init --home "$RLY_HOME"
+
+chains=($(get_chains))
+clients=($(get_clients))
+
+for chain in "${chains[@]}"; do
+    if [[ "${chain: -7}" == "testnet" ]]; then
+        rly chains add $chain --testnet --home "$RLY_HOME"
+    else
+        rly chains add $chain --home "$RLY_HOME"
+    fi
+done
+
+invalid=()
+for index in "${!chains[@]}"; do
+    echo "Checking client ${clients[$index]} on chain ${chains[$index]}" >&2
+    valid="$(is_client_valid ${chains[$index]} ${clients[$index]})"
+
+    if [[ $valid == "no" ]]; then
+        invalid+=("${clients[$index]}")
+    fi
+done
+
+if [[ "${#invalid[@]}" -gt 0 ]]; then
+    echo "Error: Incorrect trusting period for all or some clients" >&2
+    echo "Done" >&2
+    exit 1
+fi
+
+echo "Done" >&2


### PR DESCRIPTION
It adds a workflow to check if PRs to this repo which are adding/modyfing IBC paths meet requirements for clients trusting period to be 2/3 of unbonding period as stated in https://github.com/archway-network/networks#requirements-for-the-ibc-channel

The pipeline was tested on forked repo, example run: https://github.com/kayano/networks/actions/runs/6408564859/job/17397849229