### PR TITLE
fix: downgrade grpcurl to v1.8.7

### DIFF
--- a/.github/workflows/endpoints-validation.yaml
+++ b/.github/workflows/endpoints-validation.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1
         with:
           repo: fullstorydev/grpcurl
-          tag: v1.8.8
+          tag: v1.8.7
       - name: Validate changed endpoints
         if: ${{ steps.filter.outputs.chain_files != null }}
         shell: bash {0}


### PR DESCRIPTION
v1.8.8 gives the following error on valid grpc endpoints

```
Error invoking method "cosmos.base.tendermint.v1beta1.Service/GetLatestBlock": rpc error: code = Unknown desc = failed to query for service descriptor "cosmos.base.tendermint.v1beta1.Service": unexpected HTTP status code received from server: 520 (); malformed header: missing HTTP content-type
Failed to dial target host "archway-grpc.lavenderfive.com:443": context deadline exceeded
```