### PR TITLE
fix: Recreate IBC path archwaytestnet<->osmosistestnet

### DIFF
--- a/testnets/_IBC/archwaytestnet-osmosistestnet.json
+++ b/testnets/_IBC/archwaytestnet-osmosistestnet.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "archwaytestnet",
-    "client_id": "07-tendermint-77",
-    "connection_id": "connection-73"
+    "client_id": "07-tendermint-78",
+    "connection_id": "connection-74"
   },
   "chain_2": {
     "chain_name": "osmosistestnet",
-    "client_id": "07-tendermint-1195",
-    "connection_id": "connection-1101"
+    "client_id": "07-tendermint-1248",
+    "connection_id": "connection-1146"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-58",
+        "channel_id": "channel-59",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-3938",
+        "channel_id": "channel-4104",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
Recreates IBC path `archwaytestnet<->osmosistestnet` after osmo-test-5 `shadow fork` yesterday.
More info https://discord.com/channels/798583171548840026/888527537989369906/1166167074494754877

Update clients job fails with
```
2023-10-24T07:06:06.339256031Z stdout F ERROR foreign client error: error raised while updating client on chain constantine-3: failed sending message to dst chain: gRPC call `send_tx_simulate` failed with status: status: Unknown, message: "failed to execute message; message index: 0: cannot update client with ID 07-tendermint-77: trusted validators validators:<address:\"\\344\\223\\301\\322\\317#\\215\\300\\030\\211\\260\\004\\235\\2745\\274\\352\\241\\362\\251\" pub_key:<ed25519:\"\\001\\210\\335\\232\\270;\\275[\\313VT\\321\\315Z\\323\\217!\\207\\2168\\364\\240d\\027\\366\\255\\017M\\343t|\\032\" > voting_power:65010000 > proposer:<address:\"\\344\\223\\301\\322\\317#\\215\\300\\030\\211\\260\\004\\235\\2745\\274\\352\\241\\362\\251\" pub_key:<ed25519:\"\\001\\210\\335\\232\\270;\\275[\\313VT\\321\\315Z\\323\\217!\\207\\2168\\364\\240d\\027\\366\\255\\017M\\343t|\\032\" > voting_power:65010000 > total_voting_power:65010000 , does not hash to latest trusted validators. Expected: FBCD1D98886893239AE71419184BF30547E6B1D31BC368271DB5C9AC5332CED3, got: 86071DC5C9104D2E6C687140E3B53C1029B1C6C5FB96F795E82356BC908A2B9E: invalid validator set [cosmos/ibc-go/v4@v4.3.1/modules/light-clients/07-tendermint/types/update.go:156] With gas wanted: '300000000' and gas used: '87635' ", details: [], metadata: MetadataMap { headers: {"server": "openresty", "date": "Tue, 24 Oct 2023 07:06:06 GMT", "content-type": "application/grpc"} }
```