### PR TITLE
feat: Add archwaydevnet<->osmosistestnet IBC path

### DIFF
--- a/.github/workflows/ibc-path-validation.yaml
+++ b/.github/workflows/ibc-path-validation.yaml
@@ -17,8 +17,7 @@ jobs:
           list-files: shell
           filters: |
             ibc:
-              - '!devnets/_IBC/*.json'
-              - added|modified: '**/_IBC/*.json'
+              - added|modified: '(_IBC|testnets/_IBC)/*.json'
   Validation:
     needs: changes
     runs-on: ubuntu-latest

--- a/.github/workflows/ibc-path-validation.yaml
+++ b/.github/workflows/ibc-path-validation.yaml
@@ -18,6 +18,7 @@ jobs:
           filters: |
             ibc:
               - added|modified: '**/_IBC/*.json'
+              - '!devnets/_IBC/*.json'
   Validation:
     needs: changes
     runs-on: ubuntu-latest

--- a/.github/workflows/ibc-path-validation.yaml
+++ b/.github/workflows/ibc-path-validation.yaml
@@ -17,8 +17,8 @@ jobs:
           list-files: shell
           filters: |
             ibc:
-              - added|modified: '**/_IBC/*.json'
               - '!devnets/_IBC/*.json'
+              - added|modified: '**/_IBC/*.json'
   Validation:
     needs: changes
     runs-on: ubuntu-latest

--- a/devnets/_IBC/archwaydevnet-osmosistestnet.json
+++ b/devnets/_IBC/archwaydevnet-osmosistestnet.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "archwaydevnet",
+    "client_id": "07-tendermint-0",
+    "connection_id": "connection-0"
+  },
+  "chain_2": {
+    "chain_name": "osmosistestnet",
+    "client_id": "07-tendermint-1309",
+    "connection_id": "connection-1210"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-0",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-4232",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1",
+      "tags": {
+        "status": "live"
+      }
+    }
+  ]
+}

--- a/testnets/_IBC/archwaytestnet-akashtestnet.json
+++ b/testnets/_IBC/archwaytestnet-akashtestnet.json
@@ -5,6 +5,7 @@
     "client_id": "07-tendermint-45",
     "connection_id": "connection-39"
   },
+
   "chain_2": {
     "chain_name": "akashtestnet",
     "client_id": "07-tendermint-4",

--- a/testnets/_IBC/archwaytestnet-akashtestnet.json
+++ b/testnets/_IBC/archwaytestnet-akashtestnet.json
@@ -5,7 +5,6 @@
     "client_id": "07-tendermint-45",
     "connection_id": "connection-39"
   },
-
   "chain_2": {
     "chain_name": "akashtestnet",
     "client_id": "07-tendermint-4",


### PR DESCRIPTION
IBC path check can be ignored as archwaydevnet is not in cosmos chain registry so rly command cannot discover rpc for it.