### PR TITLE
fix: New ibc clients after osmosistestnet endpoints issues

### DIFF
--- a/devnets/_IBC/archwaydevnet-osmosistestnet.json
+++ b/devnets/_IBC/archwaydevnet-osmosistestnet.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "archwaydevnet",
-    "client_id": "07-tendermint-1",
-    "connection_id": "connection-1"
+    "client_id": "07-tendermint-2",
+    "connection_id": "connection-2"
   },
   "chain_2": {
     "chain_name": "osmosistestnet",
-    "client_id": "07-tendermint-1464",
-    "connection_id": "connection-1372"
+    "client_id": "07-tendermint-1533",
+    "connection_id": "connection-1428"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-1",
+        "channel_id": "channel-2",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-4400",
+        "channel_id": "channel-4466",
         "port_id": "transfer"
       },
       "ordering": "unordered",

--- a/testnets/_IBC/archwaytestnet-osmosistestnet.json
+++ b/testnets/_IBC/archwaytestnet-osmosistestnet.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "archwaytestnet",
-    "client_id": "07-tendermint-78",
-    "connection_id": "connection-74"
+    "client_id": "07-tendermint-88",
+    "connection_id": "connection-81"
   },
   "chain_2": {
     "chain_name": "osmosistestnet",
-    "client_id": "07-tendermint-1248",
-    "connection_id": "connection-1146"
+    "client_id": "07-tendermint-1532",
+    "connection_id": "connection-1427"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-59",
+        "channel_id": "channel-62",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-4104",
+        "channel_id": "channel-4465",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
After issues with public endpoints from cosmos chain registry for osmosistestnet new clients had to be created as old ones expired

Validation fails with
```
Error: post failed: Post "[https://rpc.osmotest5.osmosis.zone:443/](https://rpc.osmotest5.osmosis.zone/)": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```