### PR TITLE
Update archway-osmosis to support ICA creation

### DIFF
--- a/_IBC/archway-osmosis.json
+++ b/_IBC/archway-osmosis.json
@@ -55,6 +55,21 @@
       "tags": {
         "status": "live"
       }
+    },
+    {
+      "chain_1": {
+        "channel_id": "channel-*",
+        "port_id": "wasm.*"
+      },
+      "chain_2": {
+        "channel_id": "channel-*",
+        "port_id": "icahost"
+      },
+      "ordering": "ordered",
+      "version": "*",
+      "tags": {
+        "status": "live"
+      }
     }
   ],
   "operators": [

--- a/_IBC/archway-osmosis.json
+++ b/_IBC/archway-osmosis.json
@@ -58,11 +58,11 @@
     },
     {
       "chain_1": {
-        "channel_id": "channel-*",
+        "channel_id": "*",
         "port_id": "wasm.*"
       },
       "chain_2": {
-        "channel_id": "channel-*",
+        "channel_id": "*",
         "port_id": "icahost"
       },
       "ordering": "ordered",

--- a/_IBC/archway-osmosis.json
+++ b/_IBC/archway-osmosis.json
@@ -66,7 +66,7 @@
         "port_id": "icahost"
       },
       "ordering": "ordered",
-      "version": "*",
+      "version": "ics27-1",
       "tags": {
         "status": "live"
       }


### PR DESCRIPTION
For ICA creation we need to open new channels from `wasm.<addr>` port-id to `icahost` port-id. This PR is to enable those channel creation.

Assumption: `*` means any/all and this config file supports such wild cards.