### PR TITLE
Update archwaytestnet-osmosistestnet to support ICA creation

### DIFF
--- a/testnets/_IBC/archwaytestnet-osmosistestnet.json
+++ b/testnets/_IBC/archwaytestnet-osmosistestnet.json
@@ -25,6 +25,21 @@
       "tags": {
         "status": "live"
       }
+    },
+    {
+      "chain_1": {
+        "channel_id": "*",
+        "port_id": "wasm.*"
+      },
+      "chain_2": {
+        "channel_id": "*",
+        "port_id": "icahost"
+      },
+      "ordering": "ordered",
+      "version": "ics27-1",
+      "tags": {
+        "status": "live"
+      }
     }
   ]
 }


### PR DESCRIPTION
Refer #334 for more info. This is the same change but for testnets.