### PR TITLE
Update archwaytestnet-osmosistestnet to support ICQ

### DIFF
--- a/testnets/_IBC/archwaytestnet-osmosistestnet.json
+++ b/testnets/_IBC/archwaytestnet-osmosistestnet.json
@@ -40,6 +40,21 @@
       "tags": {
         "status": "live"
       }
+    },
+    {
+      "chain_1": {
+        "channel_id": "*",
+        "port_id": "wasm.*"
+      },
+      "chain_2": {
+        "channel_id": "*",
+        "port_id": "icqhost"
+      },
+      "ordering": "unordered",
+      "version": "icq-1",
+      "tags": {
+        "status": "live"
+      }
     }
   ]
 }


### PR DESCRIPTION
For ICQ we need to open new channels from wasm.<addr> port-id to icqhost port-id. This PR is to enable those channel creation that support ICQ.

Assumption: * means any/all and this config file supports such wild cards.
