### PR TITLE
fix: use latest client and channel info for nobletestnet (grand-1)

### DIFF
--- a/testnets/_IBC/archwaytestnet-nobletestnet.json
+++ b/testnets/_IBC/archwaytestnet-nobletestnet.json
@@ -2,22 +2,22 @@
   "$schema": "../ibc_data.schema.json",
   "chain_1": {
     "chain_name": "archwaytestnet",
-    "client_id": "07-tendermint-142",
-    "connection_id": "connection-146"
+    "client_id": "07-tendermint-144",
+    "connection_id": "connection-148"
   },
   "chain_2": {
     "chain_name": "nobletestnet",
-    "client_id": "07-tendermint-297",
-    "connection_id": "connection-250"
+    "client_id": "07-tendermint-299",
+    "connection_id": "connection-253"
   },
   "channels": [
     {
       "chain_1": {
-        "channel_id": "channel-497",
+        "channel_id": "channel-500",
         "port_id": "transfer"
       },
       "chain_2": {
-        "channel_id": "channel-212",
+        "channel_id": "channel-215",
         "port_id": "transfer"
       },
       "ordering": "unordered",


### PR DESCRIPTION
The file was created with data from this slack message:
https://phi-labs.slack.com/archives/C03JXKKHUUT/p1730730179850959?thread_ts=1730727803.428059&cid=C03JXKKHUUT

But the latest one is this one:
https://phi-labs.slack.com/archives/C03987RJV97/p1726580472654589?thread_ts=1726518166.537879&cid=C03987RJV97

So this PR updates the data to the latest one